### PR TITLE
Implement tracing fallback to log files

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1292,8 +1292,8 @@ func Test_TxRowsAffected(t *testing.T) {
 CREATE TABLE test (
 	id            TEXT PRIMARY KEY,
 	value         INT
-);`);
-	require.NoError(t, err);
+);`)
+	require.NoError(t, err)
 
 	// Insert watermark
 	err = tx(context.Background(), db, func(ctx context.Context, tx *sql.Tx) error {

--- a/app/options.go
+++ b/app/options.go
@@ -251,18 +251,18 @@ func isLoopback(iface *net.Interface) bool {
 // see https://stackoverflow.com/a/48519490/3613657
 // Valid IPv4 notations:
 //
-//    "192.168.0.1": basic
-//    "192.168.0.1:80": with port info
+//	"192.168.0.1": basic
+//	"192.168.0.1:80": with port info
 //
 // Valid IPv6 notations:
 //
-//    "::FFFF:C0A8:1": basic
-//    "::FFFF:C0A8:0001": leading zeros
-//    "0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
-//    "::FFFF:C0A8:1%1": with zone info
-//    "::FFFF:192.168.0.1": IPv4 literal
-//    "[::FFFF:C0A8:1]:80": with port info
-//    "[::FFFF:C0A8:1%1]:80": with zone and port info
+//	"::FFFF:C0A8:1": basic
+//	"::FFFF:C0A8:0001": leading zeros
+//	"0000:0000:0000:0000:0000:FFFF:C0A8:1": double colon expanded
+//	"::FFFF:C0A8:1%1": with zone info
+//	"::FFFF:192.168.0.1": IPv4 literal
+//	"[::FFFF:C0A8:1]:80": with port info
+//	"[::FFFF:C0A8:1%1]:80": with zone and port info
 func isIpV4(ip string) bool {
 	return strings.Count(ip, ":") < 2
 }

--- a/driver/tracing.go
+++ b/driver/tracing.go
@@ -1,0 +1,96 @@
+package driver
+
+import (
+	"context"
+	"database/sql/driver"
+	"sync"
+	"time"
+
+	"github.com/canonical/go-dqlite/client"
+	"github.com/canonical/go-dqlite/logging"
+	"github.com/canonical/go-dqlite/tracing"
+)
+
+type LogTracingDriver struct {
+	driver    *Driver
+	logTracer logTracer
+}
+
+func NewLogTracingDriver(driver *Driver, log logging.Func, logLevel client.LogLevel) driver.Driver {
+	return &LogTracingDriver{
+		driver: driver,
+		logTracer: logTracer{
+			log:      log,
+			logLevel: logLevel,
+		},
+	}
+}
+
+func (d *LogTracingDriver) Open(uri string) (driver.Conn, error) {
+	conn, err := d.driver.Open(uri)
+	if err != nil {
+		return nil, err
+	}
+	return &logTracingConn{
+		Conn:      conn.(*Conn),
+		logTracer: d.logTracer,
+	}, nil
+}
+
+type logTracingConn struct {
+	*Conn
+	logTracer tracing.Tracer
+}
+
+func (c *logTracingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	return c.Conn.PrepareContext(tracing.WithTracer(ctx, c.logTracer), query)
+}
+
+func (c *logTracingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return c.Conn.ExecContext(tracing.WithTracer(ctx, c.logTracer), query, args)
+}
+
+// QueryContext is an optional interface that may be implemented by a Conn.
+func (c *logTracingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	return c.Conn.QueryContext(tracing.WithTracer(ctx, c.logTracer), query, args)
+}
+
+func (c *logTracingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	return c.Conn.BeginTx(tracing.WithTracer(ctx, c.logTracer), opts)
+}
+
+// logTracer is a tracing.Tracer that is used for backwards compatibility with
+// the old tracing API to the logging API.
+type logTracer struct {
+	log      logging.Func
+	logLevel client.LogLevel
+}
+
+// Start creates a span for a given query, that will be logged when the
+// span is ended.
+func (l logTracer) Start(ctx context.Context, name, query string) (context.Context, tracing.Span) {
+	return ctx, &logTrace{
+		log: func(msg string, args ...interface{}) {
+			l.log(l.logLevel, msg, args...)
+		},
+		start: time.Now(),
+		name:  name,
+		query: query,
+	}
+}
+
+type logTrace struct {
+	log   func(msg string, args ...interface{})
+	start time.Time
+	name  string
+	query string
+	once  sync.Once
+}
+
+// End logs the end of the span. Multiple calls to End() will only log the
+// span once.
+func (l *logTrace) End() {
+	l.once.Do(func() {
+		l.log("%.3fs %s: %q", time.Since(l.start).Seconds(), l.name, l.query)
+	})
+}


### PR DESCRIPTION
The following implements a transition period where tracing is still sent to the log files via the same setup. This can be turned on via setting the tracing to anything but level.ClientNone.

The implementing just wraps the driver.Driver implementation, by pushing the logging tracer on the context for the tracing context to peel off the span.

Again, this isn't required, but does help with transitioning away from the older style method.